### PR TITLE
fix(hash): CW-22041 update hash without key issue

### DIFF
--- a/src/coolbitx/ScriptInterpreter.java
+++ b/src/coolbitx/ScriptInterpreter.java
@@ -903,7 +903,8 @@ public class ScriptInterpreter {
 					key, keyOffset, keyLength);
 		}
 		// Hashing data
-		getUpdateHash(data, offset, length, hashType);
+		// Key only update once
+		getUpdateHash(data, offset, length, hashType, key, keyOffset, (short) 0);
 		if (isUTXOtx) {
 			placeholderLength = 0;
 		} else {
@@ -1194,22 +1195,6 @@ public class ScriptInterpreter {
 			short dataLength, byte hashType, byte[] keyBuf, short keyOffset,
 			short keyLength) {
 		switch (hashType) {
-		case 0x13:
-			ShaUtil.m_blake2b_256.update(dataBuf, dataOffset, dataLength,
-					keyBuf, keyOffset, (byte) keyLength);
-			break;
-		case 0x14:
-			ShaUtil.m_blake2b_512.update(dataBuf, dataOffset, dataLength,
-					keyBuf, keyOffset, (byte) keyLength);
-			break;
-		default:
-			ISOException.throwIt((short) 0x6A0A);
-		}
-	}
-
-	private static void getUpdateHash(byte[] dataBuf, short dataOffset,
-			short dataLength, byte hashType) {
-		switch (hashType) {
 		case 2:
 		case 0xD: // double sha-256, should hash again later
 			ShaUtil.m_s_sha_256.update(dataBuf, dataOffset, dataLength);
@@ -1221,10 +1206,12 @@ public class ScriptInterpreter {
 			ShaUtil.m_blake3_256.update(dataBuf, dataOffset, dataLength);
 			break;
 		case 0x13:
-			ShaUtil.m_blake2b_256.update(dataBuf, dataOffset, dataLength);
+			ShaUtil.m_blake2b_256.update(dataBuf, dataOffset, dataLength,
+					keyBuf, keyOffset, (byte) keyLength);
 			break;
 		case 0x14:
-			ShaUtil.m_blake2b_512.update(dataBuf, dataOffset, dataLength);
+			ShaUtil.m_blake2b_512.update(dataBuf, dataOffset, dataLength,
+					keyBuf, keyOffset, (byte) keyLength);
 			break;
 		default:
 			ISOException.throwIt((short) 0x6A0A);


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request introduces changes to the `signSegmentData` and `getUpdateHash` methods for specific hash types, improving key handling during signing and hashing processes.

**Method updates:**
- Updated `signSegmentData` method to include key in hash calculation for hash types 0x13 and 0x14.
- Modified `getUpdateHash` method to include key in hash update for hash types 0x13 and 0x14.

**Hash algorithms:**
- SHA-256, Blake2b-256, Blake2b-512

**Data processing:**
- Signing: Implemented key inclusion in hash calculation for select hash types.
- Hashing: Included key in hash update for specific hash types.
- Key handling: Enhanced key handling during signing and hashing processes.

**Categories:**
1. Method updates: `signSegmentData`, `getUpdateHash`
2. Hash algorithms: SHA-256, Blake2b-256, Blake2b-512
3. Data processing: Signing, Hashing, Key handling. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>