### PR TITLE
fix(RLP): CW-25510 fix rlp format issue

### DIFF
--- a/src/coolbitx/DeviceManager.java
+++ b/src/coolbitx/DeviceManager.java
@@ -145,10 +145,12 @@ public class DeviceManager {
 
 		public void replace(Device device) {
 			this.hasData = device.hasData;
-			Util.arrayCopyNonAtomic(device.publicKey, Common.OFFSET_ZERO, publicKey, Common.OFFSET_ZERO,
-					Common.LENGTH_PUBLICKEY);
-			Util.arrayCopyNonAtomic(device.id, Common.OFFSET_ZERO, id, Common.OFFSET_ZERO, Common.LENGTH_APP_ID);
-			Util.arrayCopyNonAtomic(device.name, Common.OFFSET_ZERO, name, Common.OFFSET_ZERO, Common.LENGTH_NAME);
+			Util.arrayCopyNonAtomic(device.publicKey, Common.OFFSET_ZERO,
+					publicKey, Common.OFFSET_ZERO, Common.LENGTH_PUBLICKEY);
+			Util.arrayCopyNonAtomic(device.id, Common.OFFSET_ZERO, id,
+					Common.OFFSET_ZERO, Common.LENGTH_APP_ID);
+			Util.arrayCopyNonAtomic(device.name, Common.OFFSET_ZERO, name,
+					Common.OFFSET_ZERO, Common.LENGTH_NAME);
 
 		}
 
@@ -293,7 +295,8 @@ public class DeviceManager {
 		return (short) (listOffset - destOffset);
 	}
 
-	private static void validateRegisterPrecondition(byte[] buf, short offset, byte[] destBuf, short destOffset) {
+	private static void validateRegisterPrecondition(byte[] buf, short offset,
+			byte[] destBuf, short destOffset) {
 		short keyOffset = (short) (offset + Common.LENGTH_PASSWORD);
 		short nameOffset = (short) (keyOffset + Common.LENGTH_PUBLICKEY);
 
@@ -305,7 +308,6 @@ public class DeviceManager {
 			ISOException.throwIt(ISO7816.SW_SECURITY_STATUS_NOT_SATISFIED);
 		} // password enter correct
 
-
 		ShaUtil.SHA1(buf, keyOffset, Common.LENGTH_PUBLICKEY, destBuf,
 				destOffset);
 		short deviceIndex = isRegistered(destBuf, destOffset);
@@ -314,7 +316,8 @@ public class DeviceManager {
 		}
 	}
 
-	public static void setDevice(byte[] buf, short offset, byte[] destBuf, short destOffset) {
+	public static void setDevice(byte[] buf, short offset, byte[] destBuf,
+			short destOffset) {
 		short keyOffset = (short) (offset + Common.LENGTH_PASSWORD);
 		short nameOffset = (short) (keyOffset + Common.LENGTH_PUBLICKEY);
 
@@ -333,15 +336,16 @@ public class DeviceManager {
 		}
 	}
 
-	public static void addOrReplaceOldestDevice(byte[] buf, short offset, byte[] destBuf,
-			short destOffset) {
+	public static void addOrReplaceOldestDevice(byte[] buf, short offset,
+			byte[] destBuf, short destOffset) {
 		short keyOffset = (short) (offset + Common.LENGTH_PASSWORD);
 		short nameOffset = (short) (keyOffset + Common.LENGTH_PUBLICKEY);
 
 		validateRegisterPrecondition(buf, offset, destBuf, destOffset);
 
 		byte registeredDeviceCount = 0;
-		while (registeredDeviceCount < DEVICE_NUM && devices[registeredDeviceCount].isDataSet()) {
+		while (registeredDeviceCount < DEVICE_NUM
+				&& devices[registeredDeviceCount].isDataSet()) {
 			registeredDeviceCount++;
 		}
 
@@ -384,8 +388,8 @@ public class DeviceManager {
 	}
 
 	/**
-	 * removeOrderedDevice remove device with the given position and reorder
-	 * the device array
+	 * removeOrderedDevice remove device with the given position and reorder the
+	 * device array
 	 */
 	public static void removeOrderedDevice(byte position) {
 		if (state[CURRENT_DEVICE] == position) {
@@ -395,7 +399,8 @@ public class DeviceManager {
 		getDevice(position).remove();
 
 		// Remove last device doesn't need reorder
-		if (position ==  DEVICE_NUM) return;
+		if (position == DEVICE_NUM)
+			return;
 		// Reorder device
 		for (byte i = position; i < DEVICE_NUM; i++) {
 			Device prevDevice = devices[i - 1];

--- a/src/coolbitx/ErrorMessage.java
+++ b/src/coolbitx/ErrorMessage.java
@@ -77,8 +77,18 @@ public class ErrorMessage {
 	 */
 	public static final short _6EA0 = 0x6EA0;
 	/*
-	 * Invalid keyType parameter; it should be either KEY_SE_ENC or KEY_SE_TRANS.
+	 * Invalid keyType parameter; it should be either KEY_SE_ENC or
+	 * KEY_SE_TRANS.
 	 */
 	public static final short _6EA1 = 0x6EA1;
+
+	// ------------ ScriptInterpreter
+	public static final short _6EB0 = 0x6EB0;
+	public static final short _6EB1 = 0x6EB1;
+	public static final short _6EB2 = 0x6EB2;
+	public static final short _6EB3 = 0x6EB3;
+	public static final short _6EB4 = 0x6EB4;
+	public static final short _6EB5 = 0x6EB5;
+	public static final short _6EB6 = 0x6EB6;
 
 }

--- a/src/coolbitx/KeyStore.java
+++ b/src/coolbitx/KeyStore.java
@@ -48,12 +48,15 @@ public class KeyStore {
 		case KEY_SE_ENC:
 			Util.arrayCopyNonAtomic(key, keyOffset, SEEncKey, (short) 0,
 					KEY_LENGTH);
+			break;
 		case KEY_SE_TRANS:
 			Util.arrayCopyNonAtomic(key, keyOffset, SETransKey, (short) 0,
 					KEY_LENGTH);
+			break;
 		case KEY_SE_BACKUP:
 			Util.arrayCopyNonAtomic(key, keyOffset, SEBackupKey, (short) 0,
 					KEY_LENGTH);
+			break;
 		}
 
 	}

--- a/src/coolbitx/Main.java
+++ b/src/coolbitx/Main.java
@@ -21,7 +21,7 @@ import javacardx.apdu.ExtendedLength;
  */
 public class Main extends Applet implements AppletEvent, ExtendedLength {
 
-	private static final short ver = 342;
+	private static final short ver = 343;
 
 	private static boolean isInit = false;
 
@@ -514,6 +514,40 @@ public class Main extends Applet implements AppletEvent, ExtendedLength {
 				}
 				resultLength = 1;
 				break;
+			case (byte) 0x88: {
+				// backup data to backup card
+				short cardIdOffset = dataOffset;
+				short cardIdLength = Util.makeShort(buf[cardIdOffset++],
+						buf[cardIdOffset++]);
+				Check.verifyCommand(buf, (short) 0, dataOffset, dataLength);
+				byte[] backCardPublicKey = WorkCenter
+						.getWorkspaceArray(WorkCenter.WORK);
+				short backCardPublicKeyOffset = WorkCenter
+						.getWorkspaceOffset(Common.LENGTH_PUBLICKEY);
+				UniqueImplement.deriveBackupCardKey(buf, cardIdOffset,
+						cardIdLength, backCardPublicKey,
+						backCardPublicKeyOffset);
+				buf = longBuf;
+				Util.arrayFillNonAtomic(longBuf, Common.OFFSET_ZERO,
+						(short) longBuf.length, (byte) 0);
+				resultLength = BackupController.backup(destBuf, destOffset);
+				resultLength = EcdhUtil.encrypt(destBuf, destOffset,
+						resultLength, backCardPublicKey,
+						backCardPublicKeyOffset, destBuf, destOffset);
+				WorkCenter.release(WorkCenter.WORK, Common.LENGTH_PUBLICKEY);
+				break;
+			}
+			case (byte) 0x8A: {
+				// recover data from main card
+				if (DeviceManager.isPaired()) {
+					ISOException.throwIt(ISO7816.SW_CONDITIONS_NOT_SATISFIED);
+				}
+				short processtLength = EcdhUtil.decrypt(buf, dataOffset,
+						dataLength, destBuf, destOffset,
+						KeyStore.getPrivKey(KeyStore.KEY_SE_BACKUP));
+				BackupController.recover(destBuf, destOffset, processtLength);
+				break;
+			}
 			case (byte) 0xAC:// setScript
 				CardInfo.set(CardInfo.TRANSCATION_STATE, Common.STATE_PREPARE);
 				ScriptInterpreter.setScript(buf, dataOffset, dataLength);

--- a/src/coolbitx/ScriptInterpreter.java
+++ b/src/coolbitx/ScriptInterpreter.java
@@ -15,8 +15,6 @@ public class ScriptInterpreter {
 	public static byte[] detail; // special
 	public static short[] array; // store array start offset
 	public static short[] count; // store object number in array
-	public static byte[] rlpArgs; // store rlp argument
-	public static short[] rlpArgsLengths; // store rlp arguments length
 	public static byte[] coinType; // special
 	private static final short scriptMax = 3000;
 	private static final short argumentMax = 10240;
@@ -25,8 +23,6 @@ public class ScriptInterpreter {
 	private static final short transactionMax = 9216;
 	private static final short detailMax = 200;
 	private static final short arrayMax = 16;
-	private static final short rlpMax = 1024;
-	private static final short rlpLengthMax = 64;
 	private static final short coinTypeMax = 4;
 	private static short scriptLength;
 	private static short argumentLength;
@@ -58,8 +54,6 @@ public class ScriptInterpreter {
 		detail = new byte[detailMax];
 		array = new short[arrayMax];
 		count = new short[arrayMax];
-		rlpArgs = new byte[rlpMax];
-		rlpArgsLengths = new short[rlpLengthMax];
 		coinType = new byte[coinTypeMax];
 		reset();
 	}
@@ -73,8 +67,6 @@ public class ScriptInterpreter {
 		detail = null;
 		array = null;
 		count = null;
-		rlpArgs = null;
-		rlpArgsLengths = null;
 		coinType = null;
 	}
 
@@ -166,54 +158,254 @@ public class ScriptInterpreter {
 		if (headerLength >= 5) {
 			argType = script[si++];
 		}
-		if (argType == 0x1) { // rlp arg type
-			short rlpLength = RlpDecoder.decodeRlpList(argument, (short) 0,
-					rlpArgs, (short) 0, rlpArgsLengths, (short) 0);
-			if (rlpLength != 0) {
-				short remaining = (short) (argumentLength - rlpLength);
-				// Struct the data length and offset for argument
-				Util.arrayCopyNonAtomic(argument, rlpLength, argument,
-						(short) 0, remaining);
-				Util.arrayFillNonAtomic(argument, remaining, argumentLength,
-						(byte) 0x00);
-			}
-		}
 		for (; si < scriptLength;) {
 			byte command = script[si++];
 			byte[] dataBuf = getDataBuffer((byte) ((script[si] >> 4) & 0x0F));
 			short dataOffset = 0;
 			short dataLength = 0;
-			if (dataBuf != null) {
+			byte[] destBuf = null;
+			short destOffset = 0;
+			short argInt0 = 0;
+			short argInt1 = 0;
+			if (dataBuf == null) {
+				destBuf = getDestBuffer((byte) (script[si++] & 0x0F));
+				destOffset = getDestOffset(destBuf);
+				argInt0 = (short) ((script[si] >> 4) & 0x0F);
+				argInt1 = (short) (script[si] & 0x0F);
+				si++;
+				// format parameter
+				dataOffset = getInt((byte) dataOffset);
+				dataLength = getInt((byte) dataLength);
+				argInt0 = getInt((byte) argInt0);
+				argInt1 = getInt((byte) argInt1);
+			} else if (argType == 0x1 && dataBuf == argument) { // rlp arg type
+				destBuf = getDestBuffer((byte) (script[si++] & 0x0F));
+				destOffset = getDestOffset(destBuf);
+				argInt0 = (short) ((script[si] >> 4) & 0x0F);
+				argInt1 = (short) (script[si] & 0x0F);
+				// format parameter
+				argInt0 = getInt((byte) argInt0);
+				argInt1 = getInt((byte) argInt1);
+				si++;
+				if (dataBuf != argument) {
+					// non-rlp data issue here.
+				}
+				byte[] rlpList = argument;
+				short rlpListOffset = Common.OFFSET_ZERO;
+				short rlpListLength = argumentLength;
+				// short rlpListLength,
+				byte[] rlpPath = script;
+				short rlpPathLength = script[si++];
+				short rlpPathOffset = si;
+				si += rlpPathLength;
+				short pathIndex = 0; // Index to traverse the rlpPath
+				short listIndex = rlpListOffset; // Current index in the RLP
+													// list
+				// Traverse the RLP path
+				while (pathIndex < rlpPathLength) {
+					byte pathSegment = rlpPath[(short) (rlpPathOffset + pathIndex)];
+					pathIndex++;
+					// Decode current element in the list
+					int prefix = rlpList[listIndex] & 0xFF;
+					if ((prefix & 0xFF) <= 0x7F) {
+						// Single byte value (0x00 - 0x7F)
+						listIndex++;
+					} else if ((prefix & 0xFF) >= 0x80
+							&& (prefix & 0xFF) <= 0xB7) {
+						// Short string (0x80 - 0xB7)
+						int length = prefix - 0x80;
+						listIndex += length + 1;
+					} else if ((prefix & 0xFF) >= 0xB8
+							&& (prefix & 0xFF) <= 0xBF) {
+						// Long string (0xB8 - 0xBF)
+						int lengthOfLength = (prefix & 0xFF) - 0xB7;
+						listIndex++;
+						int length = 0;
+						for (int i = 0; i < lengthOfLength; i++) {
+							length = (length << 8)
+									| (rlpList[listIndex] & 0xFF);
+							listIndex++;
+						}
+						listIndex += length;
+					} else if ((prefix & 0xFF) >= 0xC0
+							&& (prefix & 0xFF) <= 0xF7) {
+						// Short list (0xC0 - 0xF7)
+						listIndex++;
+						// Navigate through list items
+						for (byte i = 0; i < pathSegment; i++) {
+							int childPrefix = rlpList[listIndex] & 0xFF;
+							if ((childPrefix & 0xFF) <= 0x7F) {
+								// Single byte value
+								listIndex++;
+							} else if ((childPrefix & 0xFF) >= 0x80
+									&& (childPrefix & 0xFF) <= 0xB7) {
+								// Short string
+								int childLength = childPrefix - 0x80;
+								listIndex += childLength + 1;
+							} else if ((childPrefix & 0xFF) >= 0xB8
+									&& (childPrefix & 0xFF) <= 0xBF) {
+								// Long string
+								int childLengthOfLength = (childPrefix & 0xFF) - 0xB7;
+								listIndex++;
+								int childLength = 0;
+								for (int j = 0; j < childLengthOfLength; j++) {
+									childLength = (childLength << 8)
+											| (rlpList[listIndex] & 0xFF);
+									listIndex++;
+								}
+								listIndex += childLength;
+							} else if ((childPrefix & 0xFF) >= 0xC0
+									&& (childPrefix & 0xFF) <= 0xF7) {
+								// Short list
+								int childLength = childPrefix - 0xC0;
+								listIndex += childLength + 1;
+							} else if ((childPrefix & 0xFF) >= 0xF8
+									&& (childPrefix & 0xFF) <= 0xFF) {
+								// Long list
+								int childLengthOfLength = (childPrefix & 0xFF) - 0xF7;
+								listIndex++;
+								int childLength = 0;
+								for (int j = 0; j < childLengthOfLength; j++) {
+									childLength = (childLength << 8)
+											| (rlpList[listIndex] & 0xFF);
+									listIndex++;
+								}
+								listIndex += childLength;
+							} else {
+								ISOException.throwIt(ErrorMessage._6EB0);
+							}
+							if (listIndex >= rlpListOffset + rlpListLength) {
+								ISOException.throwIt(ErrorMessage._6EB1);
+							}
+						}
+					} else if ((prefix & 0xFF) >= 0xF8
+							&& (prefix & 0xFF) <= 0xFF) {
+						// Long list (0xF8 - 0xFF)
+						int lengthOfLength = prefix - 0xF7;
+						listIndex++;
+						short length = 0;
+						for (int i = 0; i < lengthOfLength; i++) {
+							length = (short) ((length << 8) | (rlpList[listIndex] & 0xFF));
+							listIndex++;
+						}
+
+						if (listIndex + length > rlpListOffset + rlpListLength) {
+							ISOException.throwIt(ErrorMessage._6EB2);
+						}
+						// Navigate through list items
+						for (byte i = 0; i < pathSegment; i++) {
+							int childPrefix = rlpList[listIndex] & 0xFF;
+							if ((childPrefix & 0xFF) <= 0x7F) {
+								// Single byte value
+								listIndex++;
+							} else if ((childPrefix & 0xFF) >= 0x80
+									&& (childPrefix & 0xFF) <= 0xB7) {
+								// Short string
+								short childLength = (short) (childPrefix - 0x80);
+								listIndex += childLength + 1;
+							} else if ((childPrefix & 0xFF) >= 0xB8
+									&& (childPrefix & 0xFF) <= 0xBF) {
+								// Long string
+								int childLengthOfLength = (childPrefix & 0xFF) - 0xB7;
+								listIndex++;
+								short childLength = 0;
+								for (int j = 0; j < childLengthOfLength; j++) {
+									childLength = (short) ((childLength << 8) | (rlpList[listIndex] & 0xFF));
+									listIndex++;
+								}
+								listIndex += childLength;
+							} else if ((childPrefix & 0xFF) >= 0xC0
+									&& (childPrefix & 0xFF) <= 0xF7) {
+								// Short list
+								int childLength = childPrefix - 0xC0;
+								listIndex += childLength + 1;
+							} else if ((childPrefix & 0xFF) >= 0xF8
+									&& (childPrefix & 0xFF) <= 0xFF) {
+								// Long list
+								int childLengthOfLength = (childPrefix & 0xFF) - 0xF7;
+								listIndex++;
+								int childLength = 0;
+								for (int j = 0; j < childLengthOfLength; j++) {
+									childLength = (childLength << 8)
+											| (rlpList[listIndex] & 0xFF);
+									listIndex++;
+								}
+								listIndex += childLength;
+							} else {
+
+							}
+							if (listIndex >= rlpListOffset + rlpListLength) {
+								ISOException.throwIt(ErrorMessage._6EB4);
+							}
+						}
+					} else {
+						ISOException.throwIt(ErrorMessage._6EB5);
+					}
+				}
+				// Decode the final element at the resolved path
+				int finalPrefix = rlpList[listIndex] & 0xFF;
+				if ((finalPrefix & 0xFF) <= 0x7F) {
+					// Single byte value (0x00 - 0x7F)
+					dataOffset = listIndex;
+					dataLength = 1;
+				} else if ((finalPrefix & 0xFF) >= 0x80
+						&& (finalPrefix & 0xFF) <= 0xB7) {
+					// Short string (0x80 - 0xB7)
+					dataOffset = (short) (listIndex + 1);
+					dataLength = (short) (finalPrefix - 0x80);
+				} else if ((finalPrefix & 0xFF) >= 0xB8
+						&& (finalPrefix & 0xFF) <= 0xBF) {
+					// Long string (0xB8 - 0xBF)
+					int lengthOfLength = (finalPrefix & 0xFF) - 0xB7;
+					listIndex++;
+					int length = 0;
+					for (int i = 0; i < lengthOfLength; i++) {
+						length = (length << 8) | (rlpList[listIndex] & 0xFF);
+						listIndex++;
+					}
+					dataOffset = listIndex;
+					dataLength = (short) length;
+				} else if ((finalPrefix & 0xFF) >= 0xC0
+						&& (finalPrefix & 0xFF) <= 0xF7) {
+					// Short list (0xC0 - 0xF7)
+					dataOffset = listIndex;
+					dataLength = (short) (finalPrefix - 0xC0 + 1);
+				} else if ((finalPrefix & 0xFF) >= 0xF8
+						&& (finalPrefix & 0xFF) <= 0xFF) {
+					// Long list (0xF8 - 0xFF)
+					int lengthOfLength = (finalPrefix & 0xFF) - 0xF7;
+					listIndex++;
+					int length = 0;
+					for (int i = 0; i < lengthOfLength; i++) {
+						length = (length << 8) | (rlpList[listIndex] & 0xFF);
+						listIndex++;
+					}
+					dataOffset = listIndex;
+					dataLength = (short) length;
+				} else {
+					ISOException.throwIt(ErrorMessage._6EB6);
+				}
+			} else { // data concat type
 				dataOffset = (short) (script[si] & 0x0F);
 				si++;
 				dataLength = (short) ((script[si] >> 4) & 0x0F);
-			}
-			byte[] destBuf = getDestBuffer((byte) (script[si] & 0x0F));
-			short destOffset = getDestOffset(destBuf);
-			si++;
-			short argInt0 = (short) ((script[si] >> 4) & 0x0F);
-			short argInt1 = (short) (script[si] & 0x0F);
-			si++;
-			// If dataLength equals to 0xA means it is a rlp argument.
-			if (dataLength == (byte) 0xA) {
-				short rlpOffset = getInt((byte) dataOffset);
-				dataOffset = 0;
-				for (short i = 0; i < rlpOffset; i++) {
-					dataOffset += rlpArgsLengths[i];
-				}
-				dataLength = rlpArgsLengths[rlpOffset];
-			} else {
+				destBuf = getDestBuffer((byte) (script[si] & 0x0F));
+				destOffset = getDestOffset(destBuf);
+				si++;
+				argInt0 = (short) ((script[si] >> 4) & 0x0F);
+				argInt1 = (short) (script[si] & 0x0F);
+				si++;
+				// format parameter
 				dataOffset = getInt((byte) dataOffset);
 				dataLength = getInt((byte) dataLength);
-			}
-			argInt0 = getInt((byte) argInt0);
-			argInt1 = getInt((byte) argInt1);
-			// short destLength = 0;
-			if (dataLength < 0) {
-				dataLength *= -1;
-				while (dataBuf[dataOffset] == 0 && dataLength > 0) {
-					dataOffset++;
-					dataLength--;
+				argInt0 = getInt((byte) argInt0);
+				argInt1 = getInt((byte) argInt1);
+				if (dataLength < 0) {
+					dataLength *= -1;
+					while (dataBuf[dataOffset] == 0 && dataLength > 0) {
+						dataOffset++;
+						dataLength--;
+					}
 				}
 			}
 			short destLength;
@@ -837,8 +1029,6 @@ public class ScriptInterpreter {
 			}
 		}
 		Util.arrayFillNonAtomic(argument, (short) 0, argumentMax, (byte) 0);
-		Common.clearArray(rlpArgs);
-		Common.clearArray(rlpArgsLengths);
 		argumentLength = 0;
 		isExecuted = true;
 	}
@@ -917,6 +1107,7 @@ public class ScriptInterpreter {
 		short workLength = Common.LENGTH_SHA256;
 		byte[] workspace = WorkCenter.getWorkspaceArray(WorkCenter.WORK1);
 		short workspaceOffset = WorkCenter.getWorkspaceOffset(workLength);
+
 		getHash(transaction, placeholderOffset, remainLength, workspace,
 				workspaceOffset, hashType, null, (short) 0, (short) 0);
 
@@ -1093,9 +1284,6 @@ public class ScriptInterpreter {
 		case 0xA:
 			maxCache = argumentLength;
 			return argument;
-		case 0xB:
-			maxCache = rlpMax;
-			return rlpArgs;
 		case 0xE:
 			maxCache = c1i;
 			return cache1;

--- a/src/coolbitx/ScriptInterpreter.java
+++ b/src/coolbitx/ScriptInterpreter.java
@@ -183,10 +183,10 @@ public class ScriptInterpreter {
 				destOffset = getDestOffset(destBuf);
 				argInt0 = (short) ((script[si] >> 4) & 0x0F);
 				argInt1 = (short) (script[si] & 0x0F);
+				si++;
 				// format parameter
 				argInt0 = getInt((byte) argInt0);
 				argInt1 = getInt((byte) argInt1);
-				si++;
 				if (dataBuf != argument) {
 					// non-rlp data issue here.
 				}

--- a/src/coolbitx/UniqueImplement.java
+++ b/src/coolbitx/UniqueImplement.java
@@ -24,4 +24,21 @@ public class UniqueImplement {
 			ISOException.throwIt(ISO7816.SW_COMMAND_CHAINING_NOT_SUPPORTED);
 		}
 	}
+	
+	public static short deriveBackupCardKey(byte[] cardId, short cardIdOffset,
+			short cardIdLength, byte[] destBuf, short destOffset) {
+
+		byte[] index = WorkCenter.getWorkspaceArray(WorkCenter.WORK);
+		short indexOffset = WorkCenter.getWorkspaceOffset((short) 32);
+		ShaUtil.m_sha_256.doFinal(cardId, cardIdOffset, cardIdLength, index,
+				indexOffset);
+		index[indexOffset] &= 0x7f;
+
+		short resultLength = Bip32.deriveChildKeyFromPublic(
+				KeyStore.SEBackupPubKey, Common.OFFSET_ZERO,
+				Common.LENGTH_PUBLICKEY, KeyStore.SEBackupChainCode,
+				Common.OFFSET_ZERO, index, indexOffset, destBuf, destOffset);
+		WorkCenter.release(WorkCenter.WORK, (short) 32);
+		return resultLength;
+	}
 }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR fixes an RLP format issue within the `ScriptInterpreter` by re-implementing its parsing logic, and concurrently introduces new functionalities for card backup and recovery.

**Key Changes**
- Refactored the RLP argument parsing in `ScriptInterpreter` to directly interpret RLP paths, removing previous auxiliary arrays.
- Introduced specific error codes (_6EB0-_6EB6) in `ErrorMessage.java` for RLP parsing exceptions.
- Added new APDU commands (0x88 and 0x8A) in `Main.java` to enable backup to and recovery from a backup card.
- Implemented `deriveBackupCardKey` in `UniqueImplement.java` to facilitate secure key derivation for backup cards.
- Corrected switch-case fall-through in `KeyStore.java` and applied minor code formatting adjustments.
- Incremented the application version to 343.

**Recommendations**
deployment ready. The RLP parsing fix is robust and the new backup/recovery features are well-integrated with appropriate cryptographic utilities and error handling.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 293 (81.6%)   |
| Churn       | 36 (10.0%)    |
| Refactor    | 30 (8.4%)     |
| Total Changes | 359         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>