### PR TITLE
fix(RLP): CW-27284 fix rlp parsing issue

### DIFF
--- a/src/coolbitx/Main.java
+++ b/src/coolbitx/Main.java
@@ -21,7 +21,7 @@ import javacardx.apdu.ExtendedLength;
  */
 public class Main extends Applet implements AppletEvent, ExtendedLength {
 
-	private static final short ver = 344;
+	private static final short ver = 345;
 
 	private static boolean isInit = false;
 

--- a/src/coolbitx/RlpDataParser.java
+++ b/src/coolbitx/RlpDataParser.java
@@ -181,7 +181,7 @@ public class RlpDataParser {
 				length = (length << 8) | (rlpList[listIndex] & 0xFF);
 				listIndex++;
 			}
-			if (length >32767) {
+			if (length > 32767) {
 				ISOException.throwIt(ErrorMessage._6EB6);
 			}
 			dataOffset = listIndex;
@@ -198,6 +198,9 @@ public class RlpDataParser {
 			for (int i = 0; i < lengthOfLength; i++) {
 				length = (length << 8) | (rlpList[listIndex] & 0xFF);
 				listIndex++;
+			}
+			if (length > 32767) {
+				ISOException.throwIt(ErrorMessage._6EB6);
 			}
 			dataOffset = listIndex;
 			dataLength = (short) length;

--- a/src/coolbitx/RlpDataParser.java
+++ b/src/coolbitx/RlpDataParser.java
@@ -188,8 +188,9 @@ public class RlpDataParser {
 			dataLength = (short) length;
 		} else if ((finalPrefix & 0xFF) >= 0xC0 && (finalPrefix & 0xFF) <= 0xF7) {
 			// Short list (0xC0 - 0xF7)
+			listIndex++;
 			dataOffset = listIndex;
-			dataLength = (short) (finalPrefix - 0xC0 + 1);
+			dataLength = (short) (finalPrefix - 0xC0);
 		} else if ((finalPrefix & 0xFF) >= 0xF8 && (finalPrefix & 0xFF) <= 0xFF) {
 			// Long list (0xF8 - 0xFF)
 			int lengthOfLength = (finalPrefix & 0xFF) - 0xF7;

--- a/src/coolbitx/ScriptInterpreter.java
+++ b/src/coolbitx/ScriptInterpreter.java
@@ -5,7 +5,7 @@ import javacard.framework.ISOException;
 
 public class ScriptInterpreter {
 
-	public static final byte scriptVersion = 10;
+	public static final byte scriptVersion = 11;
 
 	public static byte[] script; // special
 	public static byte[] argument; // in


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR addresses an RLP (Recursive Length Prefix) parsing issue, specifically for short lists, and updates various version numbers across the application. The changes aim to improve the robustness of RLP decoding and reflect updated component versions.

#### Key Changes
- Updated the application version (`ver`) in `Main.java` from 344 to 345.
- Corrected the `dataLength` calculation for short RLP lists in `RlpDataParser.java` to accurately reflect the length.
- Added a new check in `RlpDataParser.java` to prevent integer overflow when processing long RLP lists.
- Incremented the `scriptVersion` in `ScriptInterpreter.java` from 10 to 11.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 4 (50.0%)     |
| Refactor    | 4 (50.0%)     |
| Total Changes | 8             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>